### PR TITLE
Use setTimestamp to prevent DateTimer parse exceptions

### DIFF
--- a/src/OpCacheGUI/OpCache/Status.php
+++ b/src/OpCacheGUI/OpCache/Status.php
@@ -120,8 +120,8 @@ class Status
             'blacklist_misses'     => $stats['blacklist_misses'],
             'blacklist_miss_ratio' => round($stats['blacklist_miss_ratio'], 2),
             'opcache_hit_rate'     => round($stats['opcache_hit_rate'], 2) . '%',
-            'start_time'           => (new \DateTime('@' . $stats['start_time']))->format('H:i:s d-m-Y'),
-            'last_restart_time'    => $stats['last_restart_time'] ? (new \DateTime('@' . $stats['last_restart_time']))->format('H:i:s d-m-Y') : null,
+            'start_time'           => (new \DateTime())->setTimestamp($stats['start_time'])->format('H:i:s d-m-Y'),
+            'last_restart_time'    => $stats['last_restart_time'] ? (new \DateTime())->setTimestamp($stats['last_restart_time'])->format('H:i:s d-m-Y') : null,
             'oom_restarts'         => $stats['oom_restarts'],
             'hash_restarts'        => $stats['hash_restarts'],
             'manual_restarts'      => $stats['manual_restarts'],
@@ -200,8 +200,8 @@ class Status
                 'full_path'           => $script['full_path'],
                 'hits'                => $script['hits'],
                 'memory_consumption'  => $this->byteFormatter->format($script['memory_consumption']),
-                'last_used_timestamp' => (new \DateTime('@' . $script['last_used_timestamp']))->format('H:i:s d-m-Y'),
-                'timestamp'           => (new \DateTime('@' . $script['timestamp']))->format('H:i:s d-m-Y'),
+                'last_used_timestamp' => (new \DateTime())->setTimestamp($script['last_used_timestamp'])->format('H:i:s d-m-Y'),
+                'timestamp'           => (new \DateTime())->setTimestamp($script['timestamp'])->format('H:i:s d-m-Y'),
             ];
         }
 


### PR DESCRIPTION
On PHP 5.5.9 exception is thrown:

Fatal error: Uncaught exception 'Exception' with message 'DateTime::__construct(): Failed to parse time string (@) at position 0 (@): Unexpected character' in /usr/share/webapps/OpCacheGUI/src/OpCacheGUI/OpCache/Status.php:123 Stack trace: #0 /usr/share/webapps/OpCacheGUI/src/OpCacheGUI/OpCache/Status.php(123): DateTime->__construct('@') #1 /usr/share/webapps/OpCacheGUI/template/status.phtml(39): OpCacheGUI\OpCache\Status->getStatsInfo() #2 /usr/share/webapps/OpCacheGUI/bootstrap.php(95): require('/usr/share/weba...') #3 /usr/share/webapps/OpCacheGUI/public/index.php(3): require('/usr/share/weba...') #4 {main} thrown in /usr/share/webapps/OpCacheGUI/src/OpCacheGUI/OpCache/Status.php on line 123

This PR fixes at and makes the DateTime being created from timestamp in a [PHP 5.3+ way](http://php.net/manual/en/datetime.settimestamp.php). 
