### PR TITLE
fixes error when opcache is disabled

### DIFF
--- a/src/OpCacheGUI/OpCache/Status.php
+++ b/src/OpCacheGUI/OpCache/Status.php
@@ -109,8 +109,26 @@ class Status
      */
     public function getStatsInfo()
     {
-        $stats = $this->statusData['opcache_statistics'];
+        if(!$this->statusData['opcache_enabled']) {
+           $stats = array(
+            'num_cached_scripts'   => 0,
+            'num_cached_keys'      => 0,
+            'max_cached_keys'      => 0,
+            'hits'                 => 0,
+            'misses'               => 0,
+            'blacklist_misses'     => 0,
+            'blacklist_miss_ratio' => 'n/a',
+            'opcache_hit_rate'     => 'n/a',
+            'start_time'           => time(),
+            'last_restart_time'    => time(),
+            'oom_restarts'         => 'n/a',
+            'hash_restarts'        => 'n/a',
+            'manual_restarts'      => 'n/a');
 
+        } else {
+            $stats = $this->statusData['opcache_statistics'];
+        }
+         
         return [
             'num_cached_scripts'   => $stats['num_cached_scripts'],
             'num_cached_keys'      => $stats['num_cached_keys'],


### PR DESCRIPTION
If you load the gui panel with opcache disabled in php.ini, you get an error

```
Fatal error: Uncaught exception 'Exception' with message 'DateTime::__construct(): Failed to parse time string (@time()) at position 0 (@): Unexpected character' in /var/www/opcache/src/OpCacheGUI/OpCache/Status.php:141 Stack trace: #0 /var/www/opcache/src/OpCacheGUI/OpCache/Status.php(141): DateTime->__construct('@time()') #1 /var/www/opcache/template/status.phtml(39): OpCacheGUI\OpCache\Status->getStatsInfo() #2 /var/www/opcache/bootstrap.php(95): require('/var/www/opcach...') #3 /var/www/opcache/public/index.php(3): require('/var/www/opcach...') #4 {main} thrown in /var/www/opcache/src/OpCacheGUI/OpCache/Status.php on line 141
```

So I added a verification to the getStatsInfo method to fallback to empty stats, displaying the following:

![rsz_screenshot_from_2014-07-26_134203](https://cloud.githubusercontent.com/assets/238439/3711816/02ae7cae-14ed-11e4-8ecc-8eccc2dbeae7.png)
