### PR TITLE
Added an vhost example for NginX

### DIFF
--- a/support/htpasswd.example
+++ b/support/htpasswd.example
@@ -1,0 +1,1 @@
+TestUser:2CfnzNu8dxqjs

--- a/support/nginx_vhost.example
+++ b/support/nginx_vhost.example
@@ -1,0 +1,15 @@
+server {
+    listen      80;
+    server_name opcachegui.example.com;
+    root        /var/www/OpCacheGUI/public;
+
+    auth_basic "OpCacheGUI Login";
+    auth_basic_user_file /var/www/OpCacheGUI/.htpasswd;
+
+    try_files $uri $uri/ /index.php;
+
+    location ~* \.php$ {
+        include fastcgi_params;
+        fastcgi_pass /var/run/php5-fpm.sock;
+    }
+}


### PR DESCRIPTION
This commit adds a simple example for a NginX vhost with auth support.
While researching about OpCacheGUI I came across some people who wished for this.
