### PR TITLE
Cannot use variable $request twice

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -10,7 +10,7 @@ if ($user->requiresLogin()) {
         ]);
     });
 
-    $router->post('', function() use ($htmlTemplate, $csrfToken, $request, $user, $request) {
+    $router->post('', function() use ($htmlTemplate, $csrfToken, $request, $user) {
         if ($csrfToken->validate($request->post('csrfToken')) && $user->login($request->post('username'), $request->post('password'), $request->getIp())) {
             header('Location: ' . $request->getUrl());
             exit;


### PR DESCRIPTION
OpCacheGUI in combination with PHP 7.1 throws the following error:

> PHP Fatal error:  Cannot use variable $request twice in routes.php on line 13